### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/SchwarzDigits/hypermatch/security/code-scanning/1](https://github.com/SchwarzDigits/hypermatch/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is limited to least privilege.  
The best minimal fix without changing functionality is to define workflow-level permissions right after `on:` (or before `jobs:`), with `contents: read`. This is the minimum CodeQL-recommended baseline and is sufficient for checkout and read operations in this test workflow. If later steps require additional scopes, they can be added explicitly.

**File to edit:** `.github/workflows/go-test.yml`  
**Change:** Insert:

```yml
permissions:
  contents: read
```

between the trigger section and `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
