### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,5 +1,8 @@
 name: Compliance
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push: { branches: [main] }


### PR DESCRIPTION
Potential fix for [https://github.com/SchwarzDigits/hypermatch/security/code-scanning/2](https://github.com/SchwarzDigits/hypermatch/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/compliance.yml`.  
Best placement here is at the workflow root (top-level), so it applies to all jobs (including this reusable-workflow job) unless overridden later.

For this workflow, the safest minimal non-breaking baseline from GitHub/CodeQL guidance is:

- `contents: read`

This documents intent and prevents inheriting broader defaults. If later the reusable workflow needs extra scopes, add only those specific permissions explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
